### PR TITLE
Instant Reload on Launchers

### DIFF
--- a/addons/reloadlaunchers/functions/fnc_reloadLauncher.sqf
+++ b/addons/reloadlaunchers/functions/fnc_reloadLauncher.sqf
@@ -26,5 +26,4 @@ _target selectWeapon _weapon;
 if (currentWeapon _target != _weapon) exitWith {};
 if (currentMagazine _target != "") exitWith {};
 
-// command is wip, reload time for launchers is not intended.
-_target addWeaponItem [_weapon, _magazine];
+_target addWeaponItem [_weapon, _magazine, true];


### PR DESCRIPTION
Launchers reloaded by an external player wll now be instantly reloaded,
since the the external player already goes through a loading bar.