### PR TITLE
Instantly Reload Launchers

### DIFF
--- a/addons/reloadlaunchers/functions/fnc_reloadLauncher.sqf
+++ b/addons/reloadlaunchers/functions/fnc_reloadLauncher.sqf
@@ -27,4 +27,4 @@ if (currentWeapon _target != _weapon) exitWith {};
 if (currentMagazine _target != "") exitWith {};
 
 // command is wip, reload time for launchers is not intended.
-_target addWeaponItem [_weapon, _magazine];
+_target addWeaponItem [_weapon, _magazine, true];


### PR DESCRIPTION
Launchers reloaded by an external player will be instantly loaded since
the external player already has to go through a loading bar.